### PR TITLE
use global lfs_t object instead of passing pointer everywhere

### DIFF
--- a/lfs/lfs.h
+++ b/lfs/lfs.h
@@ -365,7 +365,7 @@ typedef struct lfs_file {
     lfs_off_t off;
     lfs_cache_t cache;
 
-    const struct lfs_file_config *cfg;
+    const struct lfs_file_config* file_cfg;
 } lfs_file_t;
 
 typedef struct lfs_superblock {
@@ -408,16 +408,14 @@ typedef struct lfs {
         uint32_t *buffer;
     } free;
 
-    const struct lfs_config *cfg;
+    struct lfs_config cfg;
     lfs_size_t name_max;
     lfs_size_t file_max;
     lfs_size_t attr_max;
 
-#ifdef LFS_MIGRATE
-    struct lfs1 *lfs1;
-#endif
 } lfs_t;
 
+extern lfs_t lfs;
 
 /// Filesystem functions ///
 
@@ -429,7 +427,7 @@ typedef struct lfs {
 // be zeroed for defaults and backwards compatibility.
 //
 // Returns a negative error code on failure.
-int lfs_format(lfs_t *lfs, const struct lfs_config *config);
+int lfs_format(const struct lfs_config* config);
 #endif
 
 // Mounts a littlefs
@@ -440,13 +438,13 @@ int lfs_format(lfs_t *lfs, const struct lfs_config *config);
 // be zeroed for defaults and backwards compatibility.
 //
 // Returns a negative error code on failure.
-int lfs_mount(lfs_t *lfs, const struct lfs_config *config);
+int lfs_mount(const struct lfs_config* config);
 
 // Unmounts a littlefs
 //
 // Does nothing besides releasing any allocated resources.
 // Returns a negative error code on failure.
-int lfs_unmount(lfs_t *lfs);
+int lfs_unmount(void);
 
 /// General operations ///
 
@@ -455,7 +453,7 @@ int lfs_unmount(lfs_t *lfs);
 //
 // If removing a directory, the directory must be empty.
 // Returns a negative error code on failure.
-int lfs_remove(lfs_t *lfs, const char *path);
+int lfs_remove(const char* path);
 #endif
 
 #ifndef LFS_READONLY
@@ -465,14 +463,14 @@ int lfs_remove(lfs_t *lfs, const char *path);
 // If the destination is a directory, the directory must be empty.
 //
 // Returns a negative error code on failure.
-int lfs_rename(lfs_t *lfs, const char *oldpath, const char *newpath);
+int lfs_rename(const char* oldpath, const char* newpath);
 #endif
 
 // Find info about a file or directory
 //
 // Fills out the info structure, based on the specified file or directory.
 // Returns a negative error code on failure.
-int lfs_stat(lfs_t *lfs, const char *path, struct lfs_info *info);
+int lfs_stat(const char* path, struct lfs_info* info);
 
 // Get a custom attribute
 //
@@ -486,8 +484,7 @@ int lfs_stat(lfs_t *lfs, const char *path, struct lfs_info *info);
 // Note, the returned size is the size of the attribute on disk, irrespective
 // of the size of the buffer. This can be used to dynamically allocate a buffer
 // or check for existance.
-lfs_ssize_t lfs_getattr(lfs_t *lfs, const char *path,
-        uint8_t type, void *buffer, lfs_size_t size);
+lfs_ssize_t lfs_getattr(const char* path, uint8_t type, void* buffer, lfs_size_t size);
 
 #ifndef LFS_READONLY
 // Set custom attributes
@@ -497,8 +494,7 @@ lfs_ssize_t lfs_getattr(lfs_t *lfs, const char *path,
 // implicitly created.
 //
 // Returns a negative error code on failure.
-int lfs_setattr(lfs_t *lfs, const char *path,
-        uint8_t type, const void *buffer, lfs_size_t size);
+int lfs_setattr(const char* path, uint8_t type, const void* buffer, lfs_size_t size);
 #endif
 
 #ifndef LFS_READONLY
@@ -507,7 +503,7 @@ int lfs_setattr(lfs_t *lfs, const char *path,
 // If an attribute is not found, nothing happens.
 //
 // Returns a negative error code on failure.
-int lfs_removeattr(lfs_t *lfs, const char *path, uint8_t type);
+int lfs_removeattr(const char* path, uint8_t type);
 #endif
 
 
@@ -519,8 +515,7 @@ int lfs_removeattr(lfs_t *lfs, const char *path, uint8_t type);
 // are values from the enum lfs_open_flags that are bitwise-ored together.
 //
 // Returns a negative error code on failure.
-int lfs_file_open(lfs_t *lfs, lfs_file_t *file,
-        const char *path, int flags);
+int lfs_file_open(lfs_file_t* file, const char* path, int flags);
 
 // Open a file with extra configuration
 //
@@ -532,9 +527,8 @@ int lfs_file_open(lfs_t *lfs, lfs_file_t *file,
 // config struct must be zeroed for defaults and backwards compatibility.
 //
 // Returns a negative error code on failure.
-int lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file,
-        const char *path, int flags,
-        const struct lfs_file_config *config);
+int lfs_file_opencfg(lfs_file_t* file, const char* path, int flags,
+                     const struct lfs_file_config* config);
 
 // Close a file
 //
@@ -542,20 +536,19 @@ int lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file,
 // sync had been called and releases any allocated resources.
 //
 // Returns a negative error code on failure.
-int lfs_file_close(lfs_t *lfs, lfs_file_t *file);
+int lfs_file_close(lfs_file_t* file);
 
 // Synchronize a file on storage
 //
 // Any pending writes are written out to storage.
 // Returns a negative error code on failure.
-int lfs_file_sync(lfs_t *lfs, lfs_file_t *file);
+int lfs_file_sync(lfs_file_t* file);
 
 // Read data from file
 //
 // Takes a buffer and size indicating where to store the read data.
 // Returns the number of bytes read, or a negative error code on failure.
-lfs_ssize_t lfs_file_read(lfs_t *lfs, lfs_file_t *file,
-        void *buffer, lfs_size_t size);
+lfs_ssize_t lfs_file_read(lfs_file_t* file, void* buffer, lfs_size_t size);
 
 #ifndef LFS_READONLY
 // Write data to file
@@ -564,42 +557,39 @@ lfs_ssize_t lfs_file_read(lfs_t *lfs, lfs_file_t *file,
 // actually be updated on the storage until either sync or close is called.
 //
 // Returns the number of bytes written, or a negative error code on failure.
-lfs_ssize_t lfs_file_write(lfs_t *lfs, lfs_file_t *file,
-        const void *buffer, lfs_size_t size);
+lfs_ssize_t lfs_file_write(lfs_file_t* file, const void* buffer, lfs_size_t size);
 #endif
 
 // Change the position of the file
 //
 // The change in position is determined by the offset and whence flag.
 // Returns the new position of the file, or a negative error code on failure.
-lfs_soff_t lfs_file_seek(lfs_t *lfs, lfs_file_t *file,
-        lfs_soff_t off, int whence);
+lfs_soff_t lfs_file_seek(lfs_file_t* file, lfs_soff_t off, int whence);
 
 #ifndef LFS_READONLY
 // Truncates the size of the file to the specified size
 //
 // Returns a negative error code on failure.
-int lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size);
+int lfs_file_truncate(lfs_file_t* file, lfs_off_t size);
 #endif
 
 // Return the position of the file
 //
 // Equivalent to lfs_file_seek(lfs, file, 0, LFS_SEEK_CUR)
 // Returns the position of the file, or a negative error code on failure.
-lfs_soff_t lfs_file_tell(lfs_t *lfs, lfs_file_t *file);
+lfs_soff_t lfs_file_tell(lfs_file_t* file);
 
 // Change the position of the file to the beginning of the file
 //
 // Equivalent to lfs_file_seek(lfs, file, 0, LFS_SEEK_SET)
 // Returns a negative error code on failure.
-int lfs_file_rewind(lfs_t *lfs, lfs_file_t *file);
+int lfs_file_rewind(lfs_file_t* file);
 
 // Return the size of the file
 //
 // Similar to lfs_file_seek(lfs, file, 0, LFS_SEEK_END)
 // Returns the size of the file, or a negative error code on failure.
-lfs_soff_t lfs_file_size(lfs_t *lfs, lfs_file_t *file);
-
+lfs_soff_t lfs_file_size(lfs_file_t* file);
 
 /// Directory operations ///
 
@@ -607,27 +597,27 @@ lfs_soff_t lfs_file_size(lfs_t *lfs, lfs_file_t *file);
 // Create a directory
 //
 // Returns a negative error code on failure.
-int lfs_mkdir(lfs_t *lfs, const char *path);
+int lfs_mkdir(const char* path);
 #endif
 
 // Open a directory
 //
 // Once open a directory can be used with read to iterate over files.
 // Returns a negative error code on failure.
-int lfs_dir_open(lfs_t *lfs, lfs_dir_t *dir, const char *path);
+int lfs_dir_open(lfs_dir_t* dir, const char* path);
 
 // Close a directory
 //
 // Releases any allocated resources.
 // Returns a negative error code on failure.
-int lfs_dir_close(lfs_t *lfs, lfs_dir_t *dir);
+int lfs_dir_close(lfs_dir_t* dir);
 
 // Read an entry in the directory
 //
 // Fills out the info structure, based on the specified file or directory.
 // Returns a positive value on success, 0 at the end of directory,
 // or a negative error code on failure.
-int lfs_dir_read(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info);
+int lfs_dir_read(lfs_dir_t* dir, struct lfs_info* info);
 
 // Change the position of the directory
 //
@@ -635,7 +625,7 @@ int lfs_dir_read(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info);
 // an absolute offset in the directory seek.
 //
 // Returns a negative error code on failure.
-int lfs_dir_seek(lfs_t *lfs, lfs_dir_t *dir, lfs_off_t off);
+int lfs_dir_seek(lfs_dir_t* dir, lfs_off_t off);
 
 // Return the position of the directory
 //
@@ -643,13 +633,12 @@ int lfs_dir_seek(lfs_t *lfs, lfs_dir_t *dir, lfs_off_t off);
 // sense, but does indicate the current position in the directory iteration.
 //
 // Returns the position of the directory, or a negative error code on failure.
-lfs_soff_t lfs_dir_tell(lfs_t *lfs, lfs_dir_t *dir);
+lfs_soff_t lfs_dir_tell(lfs_dir_t* dir);
 
 // Change the position of the directory to the beginning of the directory
 //
 // Returns a negative error code on failure.
-int lfs_dir_rewind(lfs_t *lfs, lfs_dir_t *dir);
-
+int lfs_dir_rewind(lfs_dir_t* dir);
 
 /// Filesystem-level filesystem operations
 
@@ -659,7 +648,7 @@ int lfs_dir_rewind(lfs_t *lfs, lfs_dir_t *dir);
 // size may be larger than the filesystem actually is.
 //
 // Returns the number of allocated blocks, or a negative error code on failure.
-lfs_ssize_t lfs_fs_size(lfs_t *lfs);
+lfs_ssize_t lfs_fs_size(void);
 
 // Traverse through all blocks in use by the filesystem
 //
@@ -668,25 +657,7 @@ lfs_ssize_t lfs_fs_size(lfs_t *lfs);
 // blocks are in use or how much of the storage is available.
 //
 // Returns a negative error code on failure.
-int lfs_fs_traverse(lfs_t *lfs, int (*cb)(void*, lfs_block_t), void *data);
-
-#ifndef LFS_READONLY
-#ifdef LFS_MIGRATE
-// Attempts to migrate a previous version of littlefs
-//
-// Behaves similarly to the lfs_format function. Attempts to mount
-// the previous version of littlefs and update the filesystem so it can be
-// mounted with the current version of littlefs.
-//
-// Requires a littlefs object and config struct. This clobbers the littlefs
-// object, and does not leave the filesystem mounted. The config struct must
-// be zeroed for defaults and backwards compatibility.
-//
-// Returns a negative error code on failure.
-int lfs_migrate(lfs_t *lfs, const struct lfs_config *cfg);
-#endif
-#endif
-
+int lfs_fs_traverse(int (*cb)(void*, lfs_block_t), void* data);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/lfs/pico_hal.c
+++ b/lfs/pico_hal.c
@@ -47,7 +47,7 @@ struct lfs_config pico_cfg = {
     .block_cycles = 500,
 };
 
-lfs_t pico_lfs;
+lfs_t lfs;
 
 // Pico specific hardware abstraction functions
 
@@ -107,102 +107,92 @@ float hal_elapsed(void) { return (time_us_32() - tm) / 1000000.0; }
 
 int pico_mount(bool format) {
     if (format)
-        lfs_format(&pico_lfs, &pico_cfg);
+        lfs_format(&pico_cfg);
     // mount the filesystem
-    return lfs_mount(&pico_lfs, &pico_cfg);
+    return lfs_mount(&pico_cfg);
 }
 
 int pico_open(const char* path, int flags) {
     lfs_file_t* file = lfs_malloc(sizeof(lfs_file_t));
     if (file == NULL)
-        return -1;
-    int err = lfs_file_open(&pico_lfs, file, path, flags);
+        return LFS_ERR_NOMEM;
+    int err = lfs_file_open(file, path, flags);
     if (err != LFS_ERR_OK)
-        return -1;
+        return err;
     return (int)file;
 }
 
 int pico_close(int file) {
-    int res = lfs_file_close(&pico_lfs, (lfs_file_t*)file);
+    int res = lfs_file_close((lfs_file_t*)file);
     lfs_free((lfs_file_t*)file);
     return res;
 }
 
 lfs_size_t pico_write(int file, const void* buffer, lfs_size_t size) {
-    return lfs_file_write(&pico_lfs, (lfs_file_t*)file, buffer, size);
+    return lfs_file_write((lfs_file_t*)file, buffer, size);
 }
 
 lfs_size_t pico_read(int file, void* buffer, lfs_size_t size) {
-    return lfs_file_read(&pico_lfs, (lfs_file_t*)file, buffer, size);
+    return lfs_file_read((lfs_file_t*)file, buffer, size);
 }
 
-int pico_rewind(int file) { return lfs_file_rewind(&pico_lfs, (lfs_file_t*)file); }
+int pico_rewind(int file) { return lfs_file_rewind((lfs_file_t*)file); }
 
-int pico_unmount(void) { return lfs_unmount(&pico_lfs); }
+int pico_unmount(void) { return lfs_unmount(); }
 
-int pico_remove(const char* path) { return lfs_remove(&pico_lfs, path); }
+int pico_remove(const char* path) { return lfs_remove(path); }
 
-int pico_rename(const char* oldpath, const char* newpath) {
-    return lfs_rename(&pico_lfs, oldpath, newpath);
-}
+int pico_rename(const char* oldpath, const char* newpath) { return lfs_rename(oldpath, newpath); }
 
 int pico_fsstat(struct pico_fsstat_t* stat) {
     stat->block_count = pico_cfg.block_count;
     stat->block_size = pico_cfg.block_size;
-    stat->blocks_used = lfs_fs_size(&pico_lfs);
+    stat->blocks_used = lfs_fs_size();
     return LFS_ERR_OK;
 }
 
 lfs_soff_t pico_lseek(int file, lfs_soff_t off, int whence) {
-    return lfs_file_seek(&pico_lfs, (lfs_file_t*)file, off, whence);
+    return lfs_file_seek((lfs_file_t*)file, off, whence);
 }
 
-int pico_truncate(int file, lfs_off_t size) {
-    return lfs_file_truncate(&pico_lfs, (lfs_file_t*)file, size);
-}
+int pico_truncate(int file, lfs_off_t size) { return lfs_file_truncate((lfs_file_t*)file, size); }
 
-lfs_soff_t pico_tell(int file) { return lfs_file_tell(&pico_lfs, (lfs_file_t*)file); }
+lfs_soff_t pico_tell(int file) { return lfs_file_tell((lfs_file_t*)file); }
 
-int pico_stat(const char* path, struct lfs_info* info) { return lfs_stat(&pico_lfs, path, info); }
+int pico_stat(const char* path, struct lfs_info* info) { return lfs_stat(path, info); }
 
 lfs_ssize_t pico_getattr(const char* path, uint8_t type, void* buffer, lfs_size_t size) {
-    return lfs_getattr(&pico_lfs, path, type, buffer, size);
+    return lfs_getattr(path, type, buffer, size);
 }
 
 int pico_setattr(const char* path, uint8_t type, const void* buffer, lfs_size_t size) {
-    return lfs_setattr(&pico_lfs, path, type, buffer, size);
+    return lfs_setattr(path, type, buffer, size);
 }
 
-int pico_removeattr(const char* path, uint8_t type) {
-    return lfs_removeattr(&pico_lfs, path, type);
-}
+int pico_removeattr(const char* path, uint8_t type) { return lfs_removeattr(path, type); }
 
 int pico_opencfg(int file, const char* path, int flags, const struct lfs_file_config* config) {
-    return lfs_file_opencfg(&pico_lfs, (lfs_file_t*)file, path, flags, config);
+    return lfs_file_opencfg((lfs_file_t*)file, path, flags, config);
 }
 
-int pico_fflush(int file) { return lfs_file_sync(&pico_lfs, (lfs_file_t*)file); }
+int pico_fflush(int file) { return lfs_file_sync((lfs_file_t*)file); }
 
-lfs_soff_t pico_size(int file) { return lfs_file_size(&pico_lfs, (lfs_file_t*)file); }
+lfs_soff_t pico_size(int file) { return lfs_file_size((lfs_file_t*)file); }
 
-int pico_mkdir(const char* path) { return lfs_mkdir(&pico_lfs, path); }
+int pico_mkdir(const char* path) { return lfs_mkdir(path); }
 
-int pico_dir_open(int dir, const char* path) {
-    return lfs_dir_open(&pico_lfs, (lfs_dir_t*)dir, path);
-}
+int pico_dir_open(int dir, const char* path) { return lfs_dir_open((lfs_dir_t*)dir, path); }
 
-int pico_dir_close(int dir) { return lfs_dir_close(&pico_lfs, (lfs_dir_t*)dir); }
+int pico_dir_close(int dir) { return lfs_dir_close((lfs_dir_t*)dir); }
 
-int pico_dir_read(int dir, struct lfs_info* info) {
-    return lfs_dir_read(&pico_lfs, (lfs_dir_t*)dir, info);
-}
+int pico_dir_read(int dir, struct lfs_info* info) { return lfs_dir_read((lfs_dir_t*)dir, info); }
 
-int pico_dir_seek(int dir, lfs_off_t off) { return lfs_dir_seek(&pico_lfs, (lfs_dir_t*)dir, off); }
+int pico_dir_seek(int dir, lfs_off_t off) { return lfs_dir_seek((lfs_dir_t*)dir, off); }
 
-lfs_soff_t pico_dir_tell(int dir) { return lfs_dir_tell(&pico_lfs, (lfs_dir_t*)dir); }
+lfs_soff_t pico_dir_tell(int dir) { return lfs_dir_tell((lfs_dir_t*)dir); }
 
-int pico_dir_rewind(int dir) { return lfs_dir_rewind(&pico_lfs, (lfs_dir_t*)dir); }
+int pico_dir_rewind(int dir) { return lfs_dir_rewind((lfs_dir_t*)dir); }
 
 int pico_fs_traverse(int (*cb)(void*, lfs_block_t), void* data) {
-    return lfs_fs_traverse(&pico_lfs, cb, data);
+    return lfs_fs_traverse(cb, data);
 }


### PR DESCRIPTION
- saves 4K of code space and optimizes run-time